### PR TITLE
Fix custom root CA certificate installation.

### DIFF
--- a/nextcloud/README.md
+++ b/nextcloud/README.md
@@ -60,7 +60,7 @@ Don't forget to use a **strong password** for the admin account!
 - **/apps2** : Nextcloud downloaded apps.
 - **/nextcloud/themes** : Nextcloud themes location.
 - **/php/session** : php session files.
--**/etc/ssl/private**  : Internal Root-CA store for LDAPs.
+- **/etc/ssl/private**  : Internal Root-CA store for LDAPs.
 
 ### Database
 Basically, you can use a database instance running on the host or any other machine. An easier solution is to use an external database container. I suggest you to use MariaDB, which is a reliable database server. You can use the official `mariadb` image available on Docker Hub to create a database container, which must be linked to the Nextcloud container. PostgreSQL can also be used.

--- a/nextcloud/rootfs17/usr/local/bin/run.sh
+++ b/nextcloud/rootfs17/usr/local/bin/run.sh
@@ -45,8 +45,11 @@ else
     occ upgrade
 fi
 
-echo "Installing custom ROOT-CA for LDAPS..."
-   cp /etc/ssl/private/* /etc/ssl/certs/
-   update-ca-certificates
+if [ -d /etc/ssl/private ]
+then
+  echo "Installing custom CA certificates for LDAPS..."
+  find /etc/ssl/private/ -type f -exec cp {} /etc/ssl/certs/
+  update-ca-certificates
+fi
 
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d

--- a/nextcloud/rootfs17/usr/local/bin/run.sh
+++ b/nextcloud/rootfs17/usr/local/bin/run.sh
@@ -45,11 +45,12 @@ else
     occ upgrade
 fi
 
-if [ -d /etc/ssl/private ]
-then
-  echo "Installing custom CA certificates for LDAPS..."
-  find /etc/ssl/private/ -type f -exec cp {} /etc/ssl/certs/
-  update-ca-certificates
+if [ "$(find "/etc/ssl/private" -mindepth 1 -print -quit 2>/dev/null)" ]; then
+	echo "Installing custom CA certificates for LDAPS..."
+	cp /etc/ssl/private/* /etc/ssl/certs/
+	update-ca-certificates
+else
+    echo "no custom CA certificates found..."
 fi
 
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d


### PR DESCRIPTION
This code failed if no custom CA certificates were provided.

Also fixes README formatting.